### PR TITLE
Update option rom patch

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -18,16 +18,16 @@ jobs:
     needs:
       - test
     outputs:
-      release: "${{ steps.tag-release.outputs.release }}"
-      version: "${{ steps.tag-release.outputs.version }}"
+      release: "${{ steps.check-for-existing-release.outputs.release }}"
+      version: "${{ steps.check-for-existing-release.outputs.version }}"
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - shell: bash
-        id: tag-release
-        name: tag-release
+        id: check-for-existing-release
+        name: check-for-existing-release
         run: |
           VERSION=$(yq -oy '.package.version' Cargo.toml)
 
@@ -37,7 +37,7 @@ jobs:
             exit 0
           fi
 
-          echo "Continuing to create release tag for $VERSION"
+          echo "Release required for $VERSION"
 
           echo "release=true" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bridgeboard-pc-boot-patcher"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clap-num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridgeboard-pc-boot-patcher"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -5,13 +5,53 @@
 Release: [latest](https://github.com/jfharden/bridgeboard-pc-boot-patcher/releases/latest)
 
 Patch the Amiga Bridgeboard option rom in the pc.boot file in order to not use the autoboot functionality of the
-bridgeboard. This should allow an XTIDE set in the 0xC000 memory range to be used.
+bridgeboard. This should allow an XTIDE set in the 0xC000 memory range to be used, specifically I found 0xCC00 to work.
 
 It can also validate option rom checksums, and update the checksum (in the final byte of the rom).
 
+## Requirements
+
+1. An XTIDE using a recent version of the ROM (tested with r625) and using one of the ROMs which has VeryLateInit (this
+   is the default in the XT rom in the r625 XTIDE rom)
+2. An up to date version of the Bridgeboard software, tested with Janus Handler Version 36.85 and Janus Library Version
+   36.83), I used The AmigaJanus 2.1 package from https://amiga.resource.cx/exp/a2286at
+
+## Usage
+
+To create a new pc.boot file with the patch applied:
+
+```
+$ bridgeboard-pc-boot-patcher <path_to_pc.boot> write-rom <new_pc.boot_file_name> --patch-rom
+```
+
+For example, if the file is pc.boot and you want to create pc.boot.new
+
+```
+$ bridgeboard-pc-boot-patcher pc.boot write-rom pc.boot.new --patch-rom
+ORIGINAL_ROM_SIZE: 0x2000
+PATCHED_ROM_SIZE: 0x2000
+Rom written to pc.boot.new
+```
+
+You should then take that pc.boot file and copy it into SYS:PC/System/pc.boot, I strongly suggest keeping a backup of
+pc.boot on the amiga, and also if you have an aboot.ctrl file to rename it:
+
+For example, the file pc.boot.new is already in PC/System:
+
+```
+cd SYS:PC/System
+copy pc.boot pc.boot.original
+delete pc.boot
+copy pc.boot.new pc.boot
+
+# Optionally if you have an aboot.ctrl:
+rename aboot.ctrl aboot.ctrl.original
+```
+
+Make sure you have the Memory map in PCPrefs set to the D000 range.
+
+Now reboot the Amiga with the XTIDE in.
+
 ## Current Status
 
-The ROM validation and checksum updating works. The current status of the patch to the option rom contained in the
-pc.boot file doesn't work and is under current development.
-
-A more comprehensive README update will come soon.
+The ROM patch has been tested with Amiga Janus 2.1 only, and only on an Amiga 2000 with an A2286 Bridgeboard.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ Now reboot the Amiga with the XTIDE in.
 ## Current Status
 
 The ROM patch has been tested with Amiga Janus 2.1 only, and only on an Amiga 2000 with an A2286 Bridgeboard.
+
+I've only been able to test the built executable on macOS.

--- a/src/option_rom_patcher.rs
+++ b/src/option_rom_patcher.rs
@@ -6,12 +6,16 @@ use crate::option_rom::{OptionRom, OptionRomError};
 pub enum OptionRomPatcherError {
     OptionRomGenerationError(OptionRomError),
     CouldntLocateHddReadyCheck,
+    CouldntLocateAfterInt13Set,
+    JumpLengthTooBig
 }
 
 impl fmt::Display for OptionRomPatcherError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OptionRomPatcherError::CouldntLocateHddReadyCheck => write!(f, "Couldn't find the HDD ready check."),
+            OptionRomPatcherError::CouldntLocateAfterInt13Set => write!(f, "Couldn't find the end of the code which sets the INT13 handler."),
+            OptionRomPatcherError::JumpLengthTooBig => write!(f, "The distance to JMP to avoid setting INT13 is too big."),
             OptionRomPatcherError::OptionRomGenerationError(e) => write!(f, "{}", e),
         }
     }
@@ -22,7 +26,14 @@ const X86_MOV_INTO_AH: u8 = 0xb4;
 const X86_MOV_INTO_DL: u8 = 0xb2;
 const X86_POP_AX: u8 = 0x58;
 const X86_POP_DX: u8 = 0x5a;
+const X86_POP_ES: u8 = 0x07;
 const X86_JC: u8 = 0x72;
+const X86_JMP: u8 = 0xeb;
+
+const X86_MOV_SEGMENT_REGISTER_TO_MEMORY_ADDRESS: u8 = 0x8c;
+const X86_MOV_GENERAL_REGISTER_TO_MEMORY_ADDRESS: u8 = 0x89;
+const X86_ES_SEGMENT_REGISTER: u8 = 0x06;
+const X86_DI_GENERAL_REGISTER: u8 = 0x3e;
 
 const HDD_READY_CHECK_SEARCH: [u8; 9] = [
     X86_MOV_INTO_AH, 0x10,
@@ -31,6 +42,12 @@ const HDD_READY_CHECK_SEARCH: [u8; 9] = [
     X86_POP_DX,
     X86_POP_AX,
     X86_JC,
+];
+
+const INT_13_SET_FINISHED_SEARCH: [u8; 9] = [
+    X86_MOV_SEGMENT_REGISTER_TO_MEMORY_ADDRESS, X86_ES_SEGMENT_REGISTER, 0x1e, 0x20,
+    X86_MOV_GENERAL_REGISTER_TO_MEMORY_ADDRESS, X86_DI_GENERAL_REGISTER, 0x1c, 0x20,
+    X86_POP_ES,
 ];
 
 pub fn patch_rom(option_rom: &OptionRom) -> Result<OptionRom, OptionRomPatcherError> {
@@ -53,11 +70,21 @@ fn generate_patched_rom(option_rom: &OptionRom) -> Result<Vec<u8>, OptionRomPatc
         Err(e) => return Err(e),
         Ok(location) => location,
     };
+    let location_of_int_13_set_finished = match find_location_after_int_13_set(option_rom) {
+        Err(e) => return Err(e),
+        Ok(location) => location,
+    };
+
+    // Need to add 2 on the location of the jump since thats where the JMP instruction will count from
+    let jump_length: u8 = match u8::try_from(location_of_int_13_set_finished - (location_of_hdd_not_ready_jump+2)) {
+        Ok(jump_length) => jump_length,
+        Err(_) => return Err(OptionRomPatcherError::JumpLengthTooBig),
+    };
 
     let mut new_rom_bytes: Vec<u8> = option_rom.bytes[0..location_of_hdd_not_ready_jump].to_vec();
-    new_rom_bytes.push(0x1f);
-    new_rom_bytes.extend_from_slice(&option_rom.bytes[location_of_hdd_not_ready_jump+1..]);
-
+    new_rom_bytes.push(X86_JMP);
+    new_rom_bytes.push(jump_length);
+    new_rom_bytes.extend_from_slice(&option_rom.bytes[location_of_hdd_not_ready_jump+2..]);
     Ok(new_rom_bytes)
 }
 
@@ -72,9 +99,27 @@ fn find_location_of_hdd_not_ready_jump(option_rom: &OptionRom) -> Result<usize, 
            option_rom.bytes[i+6] == HDD_READY_CHECK_SEARCH[6] &&
            option_rom.bytes[i+7] == HDD_READY_CHECK_SEARCH[7] &&
            option_rom.bytes[i+8] == HDD_READY_CHECK_SEARCH[8] {
-            return Ok(i+9);
+            return Ok(i+8);
         }
     }
 
     Err(OptionRomPatcherError::CouldntLocateHddReadyCheck)
+}
+
+fn find_location_after_int_13_set(option_rom: &OptionRom) -> Result<usize, OptionRomPatcherError> {
+    for i in 0..option_rom.bytes.len()-10 {
+        if option_rom.bytes[i] == INT_13_SET_FINISHED_SEARCH[0] &&
+           option_rom.bytes[i+1] == INT_13_SET_FINISHED_SEARCH[1] &&
+           option_rom.bytes[i+2] == INT_13_SET_FINISHED_SEARCH[2] &&
+           option_rom.bytes[i+3] == INT_13_SET_FINISHED_SEARCH[3] &&
+           option_rom.bytes[i+4] == INT_13_SET_FINISHED_SEARCH[4] &&
+           option_rom.bytes[i+5] == INT_13_SET_FINISHED_SEARCH[5] &&
+           option_rom.bytes[i+6] == INT_13_SET_FINISHED_SEARCH[6] &&
+           option_rom.bytes[i+7] == INT_13_SET_FINISHED_SEARCH[7] &&
+           option_rom.bytes[i+8] == INT_13_SET_FINISHED_SEARCH[8] {
+            return Ok(i+9);
+        }
+    }
+
+    Err(OptionRomPatcherError::CouldntLocateAfterInt13Set)
 }

--- a/src/option_rom_patcher.rs
+++ b/src/option_rom_patcher.rs
@@ -7,8 +7,11 @@ pub enum OptionRomPatcherError {
     CouldntLocateInitialJump,
     OptionRomGenerationError(OptionRomError),
     CouldntLocateReturnToBIOS,
+    CouldntLocateFooter,
     NotEnoughBytesAfterReturnToBIOS,
+    NotEnoughBytesAtFooter,
     BytesAfterReturnToBIOSDontLookEmpty,
+    BytesAtFooterDontLookEmpty,
 }
 
 impl fmt::Display for OptionRomPatcherError {
@@ -16,9 +19,12 @@ impl fmt::Display for OptionRomPatcherError {
         match self {
             OptionRomPatcherError::CouldntLocateInitialJump => write!(f, "Couldn't find the initial JMP SHORT instruction."),
             OptionRomPatcherError::OptionRomGenerationError(e) => write!(f, "{}", e),
-            OptionRomPatcherError::CouldntLocateReturnToBIOS => write!(f, "Coulnd't find the expected INT 18h followed by IRET instructions"),
-            OptionRomPatcherError::NotEnoughBytesAfterReturnToBIOS => write!(f, "Not enough bytes after the return (INT 18h followed by IRET) to BIOS"),
-            OptionRomPatcherError::BytesAfterReturnToBIOSDontLookEmpty => write!(f, "The bytes after the return (INT 18h followed by IRET) to BIOS do not look empty"),
+            OptionRomPatcherError::CouldntLocateReturnToBIOS => write!(f, "Coulnd't find the expected return to bios (RETF) instruction"),
+            OptionRomPatcherError::NotEnoughBytesAfterReturnToBIOS => write!(f, "Not enough bytes after the return to BIOS (RETF) instruction"),
+            OptionRomPatcherError::BytesAfterReturnToBIOSDontLookEmpty => write!(f, "The bytes after the return to BIOS (RETF) instruction do not look empty"),
+            OptionRomPatcherError::CouldntLocateFooter => write!(f, "Coulnd't find the expected INT 18h followed by IRET instructions which preceed the empty footer space"),
+            OptionRomPatcherError::NotEnoughBytesAtFooter => write!(f, "Not enough bytes available for the footer patch"),
+            OptionRomPatcherError::BytesAtFooterDontLookEmpty => write!(f, "The bytes where the footer patch needs to go does not look empty"),
         }
     }
 }
@@ -29,24 +35,48 @@ const X86_MOV_INTO_AX: u8 = 0xA1;
 const X86_MOV_FROM_AX: u8 = 0xA1;
 const X86_PUSH_AX: u8 = 0x50;
 const X86_POP_AX: u8 = 0x58;
+const X86_POP_DS: u8 = 0x1F;
+const X86_POP_ES: u8 = 0x07;
+const X86_RET: u8 = 0xC3;
+const X86_RETF: u8 = 0xCB;
 const X86_JMP_NEAR: u8 = 0xEB;
+const X86_CALL: u8 = 0xE8;
 
-const PATCH_HEADER: [u8; 8] = [
+const PATCH_HEADER_INSTRUCTIONS: [u8; 8] = [
     X86_PUSH_AX,
     X86_MOV_INTO_AX, 0x64, 0x00,  // MOV AX, [0x0064]
     X86_PUSH_AX,
     X86_MOV_INTO_AX, 0x66, 0x00, // MOV AX, [0x0066]
 ];
 
-const PATCH_FOOTER: [u8; 8] = [
+const PATCH_FOOTER_INSTRUCTIONS: [u8; 9] = [
     X86_MOV_FROM_AX, 0x66, 0x00, // MOV [0x0066], AX
     X86_POP_AX,
     X86_MOV_FROM_AX, 0x64, 0x00, // MOV [0x0064], AX
     X86_POP_AX,
+    X86_RET,
+];
+
+const PATCH_FOOTER_SEARCH: [u8; 3] = [
+    X86_INT,
+    0x18,
+    X86_IRET,
+];
+
+const RETURN_TO_BIOS_SEARCH: [u8; 3] = [
+    X86_POP_DS,
+    X86_POP_ES,
+    X86_RETF,
+];
+
+const JUMP_TO_FOOTER_INSTRUCTIONS: [u8; 3] = [
+    X86_CALL, 0, 0 // The location of this call needs to be filled with fn generate_call_to_footer_at_location
 ];
 
 pub fn patch_rom(option_rom: &OptionRom) -> Result<OptionRom, OptionRomPatcherError> {
+    println!("ORIGINAL_ROM_SIZE: 0x{:04X}", option_rom.bytes.len());
     let patched_rom_bytes: Vec<u8> = generate_patched_rom(option_rom)?;
+    println!("PATCHED_ROM_SIZE: 0x{:04X}", patched_rom_bytes.len());
     let mut patched_rom = match OptionRom::from(patched_rom_bytes, 0) {
         Ok(patched_rom) => patched_rom,
         Err(e) => {
@@ -63,28 +93,43 @@ fn generate_patched_rom(option_rom: &OptionRom) -> Result<Vec<u8>, OptionRomPatc
         Err(e) => return Err(e),
         Ok(new_entrypoint_jump_size) => new_entrypoint_jump_size,
     };
-    let post_header_patch_location: usize = 5 + PATCH_HEADER.len();
+
+    let post_header_patch_location: usize = 5 + PATCH_HEADER_INSTRUCTIONS.len();
     let return_to_bios_location = find_location_of_return_to_bios(option_rom)?;
-    let post_footer_patch_location: usize = return_to_bios_location + PATCH_FOOTER.len() + 1;
+    let footer_location = find_location_of_footer_empty_space(option_rom)?;
+    let post_footer_location: usize = footer_location + PATCH_FOOTER_INSTRUCTIONS.len();
+    let post_return_to_bios_location: usize = return_to_bios_location + JUMP_TO_FOOTER_INSTRUCTIONS.len() + 1;
+    let call_footer_patch_instructions = generate_call_to_footer_at_location(return_to_bios_location, footer_location);
 
-    let mut new_rom_bytes: Vec<u8> = vec![OPTION_ROM_HEADER[0], OPTION_ROM_HEADER[1], option_rom.bytes[2]]; // Option ROM header
-    new_rom_bytes.extend_from_slice(&PATCH_HEADER);                     // Our patch code
-    new_rom_bytes.push(X86_JMP_NEAR);                                           // JMP SHORT
-    new_rom_bytes.push(new_entrypoint_jump_size);                       // JMP Location
+    let mut new_rom_bytes: Vec<u8> = vec![OPTION_ROM_HEADER[0], OPTION_ROM_HEADER[1], option_rom.bytes[2]];  // Option ROM header
+    new_rom_bytes.extend_from_slice(&PATCH_HEADER_INSTRUCTIONS);                                             // Our Header patch
+    new_rom_bytes.push(X86_JMP_NEAR);                                                                        // JMP SHORT
+    new_rom_bytes.push(new_entrypoint_jump_size);                                                            // JMP Location
 
-
-    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_header_patch_location..return_to_bios_location]);    // ROM upto return to bios
-    new_rom_bytes.extend_from_slice(&PATCH_FOOTER);
-    new_rom_bytes.push(X86_IRET);
-    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_footer_patch_location..]);
+    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_header_patch_location..return_to_bios_location]); // ROM upto return to bios
+    new_rom_bytes.extend_from_slice(&call_footer_patch_instructions);                                        // Call our footer patch code
+    new_rom_bytes.push(X86_RETF);                                                                            // Return Far to return control to BIOS
+    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_return_to_bios_location..footer_location]);       // The rest of the ROM from the end of the return to BIOS upto the footer
+    new_rom_bytes.extend_from_slice(&PATCH_FOOTER_INSTRUCTIONS);                                             // Our footer patch code
+    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_footer_location..]);                              // The remainder of the input file
 
     Ok(new_rom_bytes)
+}
+
+fn generate_call_to_footer_at_location(location_of_call_instruction: usize, location_of_footer: usize) -> Vec<u8> {
+    let call_offset_from = location_of_call_instruction + 0x3;
+    let call_offset = location_of_footer - call_offset_from;
+
+    let call_offset_low_byte = (call_offset & 0x00FF) as u8;
+    let call_offset_high_byte = ((call_offset & 0xFF00) >> 8) as u8;
+
+    vec![X86_CALL, call_offset_low_byte, call_offset_high_byte]
 }
 
 fn calculate_new_entrypoint_jump(option_rom: &OptionRom) -> Result<u8, OptionRomPatcherError> {
     let existing_entrypoint_jump_size = get_existing_entrypoint_jump(option_rom)?;
 
-    return Ok(existing_entrypoint_jump_size - PATCH_HEADER.len() as u8);
+    return Ok(existing_entrypoint_jump_size - PATCH_HEADER_INSTRUCTIONS.len() as u8);
 }
 
 fn get_existing_entrypoint_jump(option_rom: &OptionRom) -> Result<u8, OptionRomPatcherError> {
@@ -97,10 +142,10 @@ fn get_existing_entrypoint_jump(option_rom: &OptionRom) -> Result<u8, OptionRomP
 
 fn find_location_of_return_to_bios(option_rom: &OptionRom) -> Result<usize, OptionRomPatcherError> {
     for i in 0..option_rom.bytes.len()-3 {
-        if option_rom.bytes[i] == X86_INT && 
-           option_rom.bytes[i+1] == 0x18 && 
-           option_rom.bytes[i+2] == X86_IRET {
-            check_for_free_space(option_rom, i+3)?;
+        if option_rom.bytes[i] == RETURN_TO_BIOS_SEARCH[0] &&
+           option_rom.bytes[i+1] == RETURN_TO_BIOS_SEARCH[1] &&
+           option_rom.bytes[i+2] == RETURN_TO_BIOS_SEARCH[2] {
+            check_for_free_space_after_return_to_bios(option_rom, i+3)?;
             return Ok(i+2);
         }
     }
@@ -108,16 +153,46 @@ fn find_location_of_return_to_bios(option_rom: &OptionRom) -> Result<usize, Opti
     Err(OptionRomPatcherError::CouldntLocateReturnToBIOS)
 }
 
-fn check_for_free_space(option_rom: &OptionRom, start_position: usize) -> Result<(), OptionRomPatcherError> {
-    if option_rom.bytes.len() < start_position + PATCH_FOOTER.len() {
+fn find_location_of_footer_empty_space(option_rom: &OptionRom) -> Result<usize, OptionRomPatcherError> {
+    for i in 0..option_rom.bytes.len()-3 {
+        if option_rom.bytes[i] == PATCH_FOOTER_SEARCH[0] &&
+           option_rom.bytes[i+1] == PATCH_FOOTER_SEARCH[1] &&
+           option_rom.bytes[i+2] == PATCH_FOOTER_SEARCH[2] {
+            check_for_free_space_at_footer(option_rom, i+3)?;
+            return Ok(i+3);
+        }
+    }
+
+    Err(OptionRomPatcherError::CouldntLocateFooter)
+}
+
+
+fn check_for_free_space_after_return_to_bios(option_rom: &OptionRom, start_position: usize) -> Result<(), OptionRomPatcherError> {
+    if option_rom.bytes.len() < start_position + JUMP_TO_FOOTER_INSTRUCTIONS.len() {
         return Err(OptionRomPatcherError::NotEnoughBytesAfterReturnToBIOS);
     }
 
-    for i in 0..PATCH_FOOTER.len() {
+    for i in 0..JUMP_TO_FOOTER_INSTRUCTIONS.len() {
         // I'm not sure why but the pc.boot option rom sometimes has 0 and sometimes has 0x61 as
         // blank space
         if option_rom.bytes[start_position + i] != 0 && option_rom.bytes[start_position + i] != 0x61 {
             return Err(OptionRomPatcherError::BytesAfterReturnToBIOSDontLookEmpty);
+        }
+    }
+
+    Ok(())
+}
+
+fn check_for_free_space_at_footer(option_rom: &OptionRom, start_position: usize) -> Result<(), OptionRomPatcherError> {
+    if option_rom.bytes.len() < start_position + PATCH_FOOTER_INSTRUCTIONS.len() {
+        return Err(OptionRomPatcherError::NotEnoughBytesAtFooter);
+    }
+
+    for i in 0..PATCH_FOOTER_INSTRUCTIONS.len() {
+        // I'm not sure why but the pc.boot option rom sometimes has 0 and sometimes has 0x61 as
+        // blank space
+        if option_rom.bytes[start_position + i] != 0 && option_rom.bytes[start_position + i] != 0x61 {
+            return Err(OptionRomPatcherError::BytesAtFooterDontLookEmpty);
         }
     }
 

--- a/src/option_rom_patcher.rs
+++ b/src/option_rom_patcher.rs
@@ -1,76 +1,36 @@
 use std::fmt;
 
-use crate::option_rom::{OptionRom, OptionRomError, OPTION_ROM_HEADER};
+use crate::option_rom::{OptionRom, OptionRomError};
 
 #[derive(Debug)]
 pub enum OptionRomPatcherError {
-    CouldntLocateInitialJump,
     OptionRomGenerationError(OptionRomError),
-    CouldntLocateReturnToBIOS,
-    CouldntLocateFooter,
-    NotEnoughBytesAfterReturnToBIOS,
-    NotEnoughBytesAtFooter,
-    BytesAfterReturnToBIOSDontLookEmpty,
-    BytesAtFooterDontLookEmpty,
+    CouldntLocateHddReadyCheck,
 }
 
 impl fmt::Display for OptionRomPatcherError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            OptionRomPatcherError::CouldntLocateInitialJump => write!(f, "Couldn't find the initial JMP SHORT instruction."),
+            OptionRomPatcherError::CouldntLocateHddReadyCheck => write!(f, "Couldn't find the HDD ready check."),
             OptionRomPatcherError::OptionRomGenerationError(e) => write!(f, "{}", e),
-            OptionRomPatcherError::CouldntLocateReturnToBIOS => write!(f, "Coulnd't find the expected return to bios (RETF) instruction"),
-            OptionRomPatcherError::NotEnoughBytesAfterReturnToBIOS => write!(f, "Not enough bytes after the return to BIOS (RETF) instruction"),
-            OptionRomPatcherError::BytesAfterReturnToBIOSDontLookEmpty => write!(f, "The bytes after the return to BIOS (RETF) instruction do not look empty"),
-            OptionRomPatcherError::CouldntLocateFooter => write!(f, "Coulnd't find the expected INT 18h followed by IRET instructions which preceed the empty footer space"),
-            OptionRomPatcherError::NotEnoughBytesAtFooter => write!(f, "Not enough bytes available for the footer patch"),
-            OptionRomPatcherError::BytesAtFooterDontLookEmpty => write!(f, "The bytes where the footer patch needs to go does not look empty"),
         }
     }
 }
 
 const X86_INT: u8 = 0xCD;
-const X86_IRET: u8 = 0xCF;
-const X86_MOV_INTO_AX: u8 = 0xA1;
-const X86_MOV_FROM_AX: u8 = 0xA1;
-const X86_PUSH_AX: u8 = 0x50;
+const X86_MOV_INTO_AH: u8 = 0xb4;
+const X86_MOV_INTO_DL: u8 = 0xb2;
 const X86_POP_AX: u8 = 0x58;
-const X86_POP_DS: u8 = 0x1F;
-const X86_POP_ES: u8 = 0x07;
-const X86_RET: u8 = 0xC3;
-const X86_RETF: u8 = 0xCB;
-const X86_JMP_NEAR: u8 = 0xEB;
-const X86_CALL: u8 = 0xE8;
+const X86_POP_DX: u8 = 0x5a;
+const X86_JC: u8 = 0x72;
 
-const PATCH_HEADER_INSTRUCTIONS: [u8; 8] = [
-    X86_PUSH_AX,
-    X86_MOV_INTO_AX, 0x64, 0x00,  // MOV AX, [0x0064]
-    X86_PUSH_AX,
-    X86_MOV_INTO_AX, 0x66, 0x00, // MOV AX, [0x0066]
-];
-
-const PATCH_FOOTER_INSTRUCTIONS: [u8; 9] = [
-    X86_MOV_FROM_AX, 0x66, 0x00, // MOV [0x0066], AX
+const HDD_READY_CHECK_SEARCH: [u8; 9] = [
+    X86_MOV_INTO_AH, 0x10,
+    X86_MOV_INTO_DL, 0x80,
+    X86_INT, 0x13,
+    X86_POP_DX,
     X86_POP_AX,
-    X86_MOV_FROM_AX, 0x64, 0x00, // MOV [0x0064], AX
-    X86_POP_AX,
-    X86_RET,
-];
-
-const PATCH_FOOTER_SEARCH: [u8; 3] = [
-    X86_INT,
-    0x18,
-    X86_IRET,
-];
-
-const RETURN_TO_BIOS_SEARCH: [u8; 3] = [
-    X86_POP_DS,
-    X86_POP_ES,
-    X86_RETF,
-];
-
-const JUMP_TO_FOOTER_INSTRUCTIONS: [u8; 3] = [
-    X86_CALL, 0, 0 // The location of this call needs to be filled with fn generate_call_to_footer_at_location
+    X86_JC,
 ];
 
 pub fn patch_rom(option_rom: &OptionRom) -> Result<OptionRom, OptionRomPatcherError> {
@@ -89,112 +49,32 @@ pub fn patch_rom(option_rom: &OptionRom) -> Result<OptionRom, OptionRomPatcherEr
 }
 
 fn generate_patched_rom(option_rom: &OptionRom) -> Result<Vec<u8>, OptionRomPatcherError> {
-    let new_entrypoint_jump_size: u8 = match calculate_new_entrypoint_jump(option_rom) {
+    let location_of_hdd_not_ready_jump = match find_location_of_hdd_not_ready_jump(option_rom) {
         Err(e) => return Err(e),
-        Ok(new_entrypoint_jump_size) => new_entrypoint_jump_size,
+        Ok(location) => location,
     };
 
-    let post_header_patch_location: usize = 5 + PATCH_HEADER_INSTRUCTIONS.len();
-    let return_to_bios_location = find_location_of_return_to_bios(option_rom)?;
-    let footer_location = find_location_of_footer_empty_space(option_rom)?;
-    let post_footer_location: usize = footer_location + PATCH_FOOTER_INSTRUCTIONS.len();
-    let post_return_to_bios_location: usize = return_to_bios_location + JUMP_TO_FOOTER_INSTRUCTIONS.len() + 1;
-    let call_footer_patch_instructions = generate_call_to_footer_at_location(return_to_bios_location, footer_location);
-
-    let mut new_rom_bytes: Vec<u8> = vec![OPTION_ROM_HEADER[0], OPTION_ROM_HEADER[1], option_rom.bytes[2]];  // Option ROM header
-    new_rom_bytes.extend_from_slice(&PATCH_HEADER_INSTRUCTIONS);                                             // Our Header patch
-    new_rom_bytes.push(X86_JMP_NEAR);                                                                        // JMP SHORT
-    new_rom_bytes.push(new_entrypoint_jump_size);                                                            // JMP Location
-
-    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_header_patch_location..return_to_bios_location]); // ROM upto return to bios
-    new_rom_bytes.extend_from_slice(&call_footer_patch_instructions);                                        // Call our footer patch code
-    new_rom_bytes.push(X86_RETF);                                                                            // Return Far to return control to BIOS
-    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_return_to_bios_location..footer_location]);       // The rest of the ROM from the end of the return to BIOS upto the footer
-    new_rom_bytes.extend_from_slice(&PATCH_FOOTER_INSTRUCTIONS);                                             // Our footer patch code
-    new_rom_bytes.extend_from_slice(&option_rom.bytes[post_footer_location..]);                              // The remainder of the input file
+    let mut new_rom_bytes: Vec<u8> = option_rom.bytes[0..location_of_hdd_not_ready_jump].to_vec();
+    new_rom_bytes.push(0x1f);
+    new_rom_bytes.extend_from_slice(&option_rom.bytes[location_of_hdd_not_ready_jump+1..]);
 
     Ok(new_rom_bytes)
 }
 
-fn generate_call_to_footer_at_location(location_of_call_instruction: usize, location_of_footer: usize) -> Vec<u8> {
-    let call_offset_from = location_of_call_instruction + 0x3;
-    let call_offset = location_of_footer - call_offset_from;
-
-    let call_offset_low_byte = (call_offset & 0x00FF) as u8;
-    let call_offset_high_byte = ((call_offset & 0xFF00) >> 8) as u8;
-
-    vec![X86_CALL, call_offset_low_byte, call_offset_high_byte]
-}
-
-fn calculate_new_entrypoint_jump(option_rom: &OptionRom) -> Result<u8, OptionRomPatcherError> {
-    let existing_entrypoint_jump_size = get_existing_entrypoint_jump(option_rom)?;
-
-    return Ok(existing_entrypoint_jump_size - PATCH_HEADER_INSTRUCTIONS.len() as u8);
-}
-
-fn get_existing_entrypoint_jump(option_rom: &OptionRom) -> Result<u8, OptionRomPatcherError> {
-    if option_rom.bytes[3] != X86_JMP_NEAR {
-        return Err(OptionRomPatcherError::CouldntLocateInitialJump)
-    }
-
-    Ok(option_rom.bytes[4])
-}
-
-fn find_location_of_return_to_bios(option_rom: &OptionRom) -> Result<usize, OptionRomPatcherError> {
-    for i in 0..option_rom.bytes.len()-3 {
-        if option_rom.bytes[i] == RETURN_TO_BIOS_SEARCH[0] &&
-           option_rom.bytes[i+1] == RETURN_TO_BIOS_SEARCH[1] &&
-           option_rom.bytes[i+2] == RETURN_TO_BIOS_SEARCH[2] {
-            check_for_free_space_after_return_to_bios(option_rom, i+3)?;
-            return Ok(i+2);
+fn find_location_of_hdd_not_ready_jump(option_rom: &OptionRom) -> Result<usize, OptionRomPatcherError> {
+    for i in 0..option_rom.bytes.len()-10 {
+        if option_rom.bytes[i] == HDD_READY_CHECK_SEARCH[0] &&
+           option_rom.bytes[i+1] == HDD_READY_CHECK_SEARCH[1] &&
+           option_rom.bytes[i+2] == HDD_READY_CHECK_SEARCH[2] &&
+           option_rom.bytes[i+3] == HDD_READY_CHECK_SEARCH[3] &&
+           option_rom.bytes[i+4] == HDD_READY_CHECK_SEARCH[4] &&
+           option_rom.bytes[i+5] == HDD_READY_CHECK_SEARCH[5] &&
+           option_rom.bytes[i+6] == HDD_READY_CHECK_SEARCH[6] &&
+           option_rom.bytes[i+7] == HDD_READY_CHECK_SEARCH[7] &&
+           option_rom.bytes[i+8] == HDD_READY_CHECK_SEARCH[8] {
+            return Ok(i+9);
         }
     }
 
-    Err(OptionRomPatcherError::CouldntLocateReturnToBIOS)
-}
-
-fn find_location_of_footer_empty_space(option_rom: &OptionRom) -> Result<usize, OptionRomPatcherError> {
-    for i in 0..option_rom.bytes.len()-3 {
-        if option_rom.bytes[i] == PATCH_FOOTER_SEARCH[0] &&
-           option_rom.bytes[i+1] == PATCH_FOOTER_SEARCH[1] &&
-           option_rom.bytes[i+2] == PATCH_FOOTER_SEARCH[2] {
-            check_for_free_space_at_footer(option_rom, i+3)?;
-            return Ok(i+3);
-        }
-    }
-
-    Err(OptionRomPatcherError::CouldntLocateFooter)
-}
-
-
-fn check_for_free_space_after_return_to_bios(option_rom: &OptionRom, start_position: usize) -> Result<(), OptionRomPatcherError> {
-    if option_rom.bytes.len() < start_position + JUMP_TO_FOOTER_INSTRUCTIONS.len() {
-        return Err(OptionRomPatcherError::NotEnoughBytesAfterReturnToBIOS);
-    }
-
-    for i in 0..JUMP_TO_FOOTER_INSTRUCTIONS.len() {
-        // I'm not sure why but the pc.boot option rom sometimes has 0 and sometimes has 0x61 as
-        // blank space
-        if option_rom.bytes[start_position + i] != 0 && option_rom.bytes[start_position + i] != 0x61 {
-            return Err(OptionRomPatcherError::BytesAfterReturnToBIOSDontLookEmpty);
-        }
-    }
-
-    Ok(())
-}
-
-fn check_for_free_space_at_footer(option_rom: &OptionRom, start_position: usize) -> Result<(), OptionRomPatcherError> {
-    if option_rom.bytes.len() < start_position + PATCH_FOOTER_INSTRUCTIONS.len() {
-        return Err(OptionRomPatcherError::NotEnoughBytesAtFooter);
-    }
-
-    for i in 0..PATCH_FOOTER_INSTRUCTIONS.len() {
-        // I'm not sure why but the pc.boot option rom sometimes has 0 and sometimes has 0x61 as
-        // blank space
-        if option_rom.bytes[start_position + i] != 0 && option_rom.bytes[start_position + i] != 0x61 {
-            return Err(OptionRomPatcherError::BytesAtFooterDontLookEmpty);
-        }
-    }
-
-    Ok(())
+    Err(OptionRomPatcherError::CouldntLocateHddReadyCheck)
 }


### PR DESCRIPTION
This new option ROM patch takes a new approach.

You can't just skip the whole Option ROM since that disables the ability to use AREAD/AWRITE/AMOUSE.

In the Option ROM contained within the pc.boot file it looks to see if the hard drive is ready, if it's not ready it sets the INT13 vector to be a location within the option ROM and also sets the INT19 vector to be another location within the ROM. If it is ready it sets the INT13 vector to be a third location in the ROM.

All of these interfere with the XTIDE, so this patch will search for where the decision is made and skip to after all the INT13 and INT19 vector setups.

The XTIDE ROM needs to be one with the VeryLateInit (meaning one of the current XT roms) so it installs itself into INT19 and then sets itself up after the pc.boot ROM has completed its setup.

Since we're only skipping the hard drive controller setup the AMOUSE/AREAD/AWRITE commands all work. I suspect the JLINK functionality wont work, and surely the ability to have a virtual disk on the Amigas hard drive wont work (configured with the aboot.ctrl on the Amiga).