### PR TITLE
Allow locations specified in hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,9 +70,10 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bridgeboard-pc-boot-patcher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
+ "clap-num",
  "md5",
  "tempfile",
 ]
@@ -85,6 +92,15 @@ checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-num"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e063d263364859dc54fb064cedb7c122740cd4733644b14b176c097f51e8ab7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -162,6 +178,15 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "bridgeboard-pc-boot-patcher"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "^4.4", features = ["derive"] }
+clap-num = "1"
 
 [dev-dependencies]
 md5 = "0.7"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand, Args};
+use clap_num::maybe_hex;
 
 #[derive(Parser)]
 #[command(author, version)]
@@ -28,7 +29,7 @@ pub struct SourceArgs {
     pub source_path: std::path::PathBuf,
 
     /// ROM location in the file (in hex if specified with a leading 0x)
-    #[arg(short, long, conflicts_with = "scan")]
+    #[arg(short, long, conflicts_with = "scan", value_parser=maybe_hex::<usize>)]
     pub location: Option<usize>,
 
     /// Scan in the source file for an Option Rom


### PR DESCRIPTION
Allow args to the --location flag to be passed as hex (as promised in the help)